### PR TITLE
Lis3mdl spi

### DIFF
--- a/boards/arm/blerns/Kconfig.defconfig
+++ b/boards/arm/blerns/Kconfig.defconfig
@@ -12,16 +12,16 @@ config BOARD
 if UART_NRFX
 
 config UART_0_NRF_TX_PIN
-	default 19
+	default 27
 
 config UART_0_NRF_RX_PIN
-	default 21
+	default 28
 
 config UART_0_NRF_RTS_PIN
-	default 23
+	default 29
 
 config UART_0_NRF_CTS_PIN
-	default 25
+	default 30
 
 if MODEM_WNCM14A2A
 

--- a/boards/arm/blerns/blerns.dts
+++ b/boards/arm/blerns/blerns.dts
@@ -70,11 +70,13 @@
 	scl-pin = <7>;
 };
 
+/*
 &i2c1 {
 	status = "ok";
 	sda-pin = <16>;
 	scl-pin = <14>;
 };
+*/
 
 &flash0 {
 	/*

--- a/drivers/sensor/icm20649/icm20649.c
+++ b/drivers/sensor/icm20649/icm20649.c
@@ -908,8 +908,6 @@ static void icm20649_thread_cb(void *arg)
 	struct device *dev = arg;
 	struct icm20649_data *drv_data = dev->driver_data;
 
-    SYS_LOG_DBG("Interrupt triggered");
-
 	// read data from fifo as an array of s16_t's up to 512bytes worth
     // pass data to callback given at setup time
 	if (drv_data->data_ready_handler != NULL) {

--- a/drivers/sensor/lis3mdl/CMakeLists.txt
+++ b/drivers/sensor/lis3mdl/CMakeLists.txt
@@ -1,4 +1,6 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_LIS3MDL lis3mdl.c)
+zephyr_library_sources_ifdef(CONFIG_LIS3MDL_SPI lis3mdl_spi.c)
+zephyr_library_sources_ifdef(CONFIG_LIS3MDL_I2C lis3mdl_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_LIS3MDL_TRIGGER lis3mdl_trigger.c)

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2016 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -6,18 +5,32 @@
 
 menuconfig LIS3MDL
 	bool "LIS3MDL magnetometer"
-	depends on I2C
+	depends on SENSOR && (I2C || SPI)
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 
-if !HAS_DTS_I2C_DEVICE
-
-config LIS3MDL_NAME
-	string "Driver name"
-	default "LIS3MDL"
+choice LIS3MDL_BUS_TYPE
+	prompt "Interface to AP"
 	depends on LIS3MDL
 	help
-	  Device name with which the LIS3MDL sensor is identified.
+	  Select interface the LIS3MDL driver is connected to AP
+
+config LIS3MDL_I2C
+	depends on I2C
+	bool "I2C Interface"
+
+config LIS3MDL_SPI
+	depends on SPI
+	bool "SPI Interface"
+
+endchoice
+
+config LIS3MDL_DEV_NAME
+	string "LIS3MDL device name"
+	depends on (LIS3MDL_I2C && !HAS_DTS_I2C_DEVICE) || LIS3MDL_SPI
+	default "LIS3MDL"
+
+if !HAS_DTS_I2C_DEVICE
 
 config LIS3MDL_I2C_ADDR
 	hex "I2C address"
@@ -36,7 +49,108 @@ config LIS3MDL_I2C_MASTER_DEV_NAME
 	  Specify the device name of the I2C master device to which LIS3MDL is
 	  connected.
 
-endif
+config LIS3MDL_I2C_GPIO_CS
+	bool "LIS3MDL CS I2C enable set through a GPIO pin"
+	depends on LIS3MDL && LIS3MDL_I2C
+	help
+	  This option is useful if one needs to manage CS through a GPIO
+	  which must be set high for I2C operations.
+
+config LIS3MDL_I2C_GPIO_SA1
+	bool "LIS3MDL I2C SA1 through a GPIO pin"
+	depends on LIS3MDL && LIS3MDL_I2C
+	help
+	  This option is useful if one needs to manage SA1 through a GPIO
+	  which may be adjusted to set the I2C address.
+
+config LIS3MDL_I2C_GPIO_CS_DRV_NAME
+	string "GPIO driver's name to use to drive CS through"
+	default ""
+	depends on LIS3MDL_I2C_GPIO_CS
+	help
+	  This option is mandatory to set which GPIO controller to use in order
+	  to actually set CS.
+
+config LIS3MDL_I2C_GPIO_CS_PIN
+	int "GPIO PIN to use to drive CS through"
+	default 0
+	depends on LIS3MDL_I2C_GPIO_CS
+	help
+	  This option is mandatory to set which GPIO pin to use in order
+	  to actually set CS.
+
+config LIS3MDL_I2C_GPIO_SA1_DRV_NAME
+	string "GPIO driver's name to use to drive SA1 through"
+	default ""
+	depends on LIS3MDL_I2C_GPIO_SA1
+	help
+	  This option is mandatory to set which GPIO controller to use in order
+	  to actually set SA1 which is used to adjust the I2C address.
+
+config LIS3MDL_I2C_GPIO_SA1_PIN
+	int "GPIO PIN to use to drive CS through"
+	default 0
+	depends on LIS3MDL_I2C_GPIO_SA1
+	help
+	  This option is mandatory to set which GPIO pin to use in order
+	  to actually set CS.
+
+endif #HAS_DTS_I2C_DEVICE
+
+if !HAS_DTS_SPI_DEVICE
+
+config LIS3MDL_SPI_SELECT_SLAVE
+	hex "LIS3MDL SPI slave select pin"
+	depends on LIS3MDL && LIS3MDL_SPI
+	default 1
+	help
+	  LIS3MDL SPI chip select pin (active low).
+
+config LIS3MDL_SPI_BUS_FREQ
+	int "LIS3MDL SPI bus speed in Hz"
+	default 8000000
+	depends on LIS3MDL && LIS3MDL_SPI
+	help
+	  This is the maximum supported SPI bus frequency. The chip supports a
+	  frequency up to 10MHz.
+
+config LIS3MDL_SPI_MASTER_DEV_NAME
+	string "SPI master name where LIS3MDL chip is connected"
+	depends on LIS3MDL && LIS3MDL_SPI
+	default "SPI_2"
+	help
+	  Specify the device name of the spi master device to which LIS3MDL is
+	  connected.
+
+endif #HAS_DTS_SPI_DEVICE
+
+config LIS3MDL_SPI_GPIO_CS
+	bool "LIS3MDL SPI CS through a GPIO pin"
+	depends on LIS3MDL && LIS3MDL_SPI
+	help
+	  This option is useful if one needs to manage SPI CS through a GPIO
+	  pin to by-pass the SPI controller's CS logic.
+
+if !HAS_DTS_SPI_PINS
+
+config LIS3MDL_SPI_GPIO_CS_DRV_NAME
+	string "GPIO driver's name to use to drive SPI CS through"
+	default ""
+	depends on LIS3MDL_SPI_GPIO_CS
+	help
+	  This option is mandatory to set which GPIO controller to use in order
+	  to actually emulate the SPI CS.
+
+config LIS3MDL_SPI_GPIO_CS_PIN
+	int "GPIO PIN to use to drive SPI CS through"
+	default 0
+	depends on LIS3MDL_SPI_GPIO_CS
+	help
+	  This option is mandatory to set which GPIO pin to use in order
+	  to actually emulate the SPI CS.
+
+endif # !HAS_DTS_SPI_PINS
+
 
 choice LIS3MDL_TRIGGER_MODE
 	prompt "Trigger mode"
@@ -58,6 +172,11 @@ config LIS3MDL_TRIGGER_OWN_THREAD
 	depends on GPIO
 	select LIS3MDL_TRIGGER
 
+config LIS3MDL_TRIGGER_IRQ
+	bool "Trigger callback is run in the interrupt callback"
+	depends on GPIO
+	select LIS3MDL_TRIGGER
+
 endchoice # LIS3MDL_TRIGGER_MODE
 
 config LIS3MDL_TRIGGER
@@ -72,21 +191,13 @@ config LIS3MDL_GPIO_DEV_NAME
 	  The device name of the GPIO device to which the LIS3MDL interrupt pins
 	  are connected.
 
-config LIS3MDL_GPIO_INT_PIN_NUM
-	int "Interrupt GPIO pin number"
+config LIS3MDL_GPIO_DRDY_PIN_NUM
+	int "Dataready GPIO pin number"
 	default 0
 	depends on LIS3MDL && LIS3MDL_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the LIS3MDL
 	  chip will be received.
-
-config LIS3MDL_GPIO_CS_PIN_NUM
-	int "Chip select pin used to determine SPI/I2C connectivity"
-	default 0
-	depends on LIS3MDL
-	help
-	  The number of the GPIO on which the CS signal to the LIS3MDL
-	  chip will be sent.
 
 config LIS3MDL_GPIO_SA1_PIN_NUM
 	int "I2C Address pin if I2C is used, optionally set the address pin high/low to adjust the address"

--- a/drivers/sensor/lis3mdl/lis3mdl.h
+++ b/drivers/sensor/lis3mdl/lis3mdl.h
@@ -11,6 +11,7 @@
 #include <misc/util.h>
 #include <zephyr/types.h>
 #include <gpio.h>
+#include <sensor.h>
 
 #define SYS_LOG_DOMAIN "LIS3MDL"
 #define SYS_LOG_LEVEL CONFIG_SYS_LOG_SENSOR_LEVEL
@@ -119,8 +120,19 @@ static const u16_t lis3mdl_magn_gain[] = {
 	6842, 3421, 2281, 1711
 };
 
+struct lis3mdl_data;
+
+struct lis3mdl_transfer_function {
+	int (*read_data)(struct lis3mdl_data *data, u8_t reg_addr,
+                   u8_t *value, u8_t len);
+	int (*write_data)(struct lis3mdl_data *data, u8_t reg_addr,
+                    u8_t *value, u8_t len);
+	int (*read_reg)(struct lis3mdl_data *data, u8_t reg_addr,
+                  u8_t *value);
+};
+
 struct lis3mdl_data {
-	struct device *i2c;
+	struct device *comm_master;
 	s16_t x_sample;
 	s16_t y_sample;
 	s16_t z_sample;
@@ -141,15 +153,19 @@ struct lis3mdl_data {
 	struct k_work work;
 	struct device *dev;
 #endif
-
 #endif /* CONFIG_LIS3MDL_TRIGGER */
+
+	const struct lis3mdl_transfer_function *hw_tf;
 };
 
+int lis3mdl_spi_init(struct lis3mdl_data *drv_data);
+int lis3mdl_i2c_init(struct lis3mdl_data *drv_data);
 #ifdef CONFIG_LIS3MDL_TRIGGER
 int lis3mdl_trigger_set(struct device *dev,
 			const struct sensor_trigger *trig,
 			sensor_trigger_handler_t handler);
 
+int lis3mdl_sample_fetch_drv(struct lis3mdl_data *drv_data, enum sensor_channel chan);
 int lis3mdl_sample_fetch(struct device *dev, enum sensor_channel chan);
 
 int lis3mdl_init_interrupt(struct device *dev);

--- a/drivers/sensor/lis3mdl/lis3mdl_i2c.c
+++ b/drivers/sensor/lis3mdl/lis3mdl_i2c.c
@@ -1,0 +1,72 @@
+#include <i2c.h>
+#include "lis3mdl.h"
+
+static u16_t lis3mdl_i2c_slave_addr = CONFIG_LIS3MDL_I2C_ADDR;
+
+static int lis3mdl_i2c_read_data(struct lis3mdl_data *data, u8_t reg_addr,
+                                 u8_t *value, u8_t len)
+{
+	return i2c_burst_read(data->comm_master, lis3mdl_i2c_slave_addr,
+                        reg_addr, value, len);
+}
+
+static int lis3mdl_i2c_write_data(struct lis3mdl_data *data, u8_t reg_addr,
+                                  u8_t *value, u8_t len)
+{
+	return i2c_burst_write(data->comm_master, lis3mdl_i2c_slave_addr,
+                         reg_addr, value, len);
+}
+
+static int lis3mdl_i2c_read_reg(struct lis3mdl_data *data, u8_t reg_addr,
+                                u8_t *value)
+{
+	return i2c_reg_read_byte(data->comm_master, lis3mdl_i2c_slave_addr,
+                           reg_addr, value);
+}
+
+static struct lis3mdl_transfer_function lis3mdl_i2c_tf = {
+	.read_data = lis3mdl_i2c_read_data,
+	.write_data = lis3mdl_i2c_write_data,
+	.read_reg = lis3mdl_i2c_read_reg,
+};
+
+int lis3mdl_i2c_init(struct lis3mdl_data *drv_data) {
+	int res = 0;
+
+#ifdef CONFIG_LIS3MDL_I2C_GPIO_CS
+	struct device *cs_gpio = device_get_binding(CONFIG_LIS3MDL_I2C_GPIO_CS_DRV_NAME);
+	res = gpio_pin_configure(cs_gpio, CONFIG_LIS3MDL_I2C_GPIO_CS_PIN_NUM, GPIO_DIR_OUT);
+	if(res != 0) {
+		SYS_LOG_ERR("Could not configure CS pin for I2C usage, %d cause res %d", CONFIG_LIS3MDL_I2C_GPIO_CS_PIN_NUM, res);
+		return -EINVAL;
+	}
+	res = gpio_pin_write(cs_gpio, CONFIG_LIS3MDL_I2C_GPIO_CS_PIN_NUM, 1);
+	if(res != 0) {
+		SYS_LOG_ERR("Could not write CS pin for I2C usage, %d cause res %d", CONFIG_LIS3MDL_I2C_GPIO_CS_PIN_NUM, res);
+		return -EINVAL;
+	}
+#endif
+
+#ifdef CONFIG_LIS3MDL_I2C_GPIO_SA1
+	struct device *sa1_gpio = device_get_binding(CONFIG_LIS3MDL_I2C_GPIO_SA1_DRV_NAME);
+	res = gpio_pin_configure(sa1_gpio, CONFIG_LIS3MDL_GPIO_SA1_PIN_NUM, GPIO_DIR_OUT | GPIO_PUD_PULL_DOWN);
+	if(res != 0) {
+		SYS_LOG_ERR("Could not configure SA1 pin, %d cause res %d", CONFIG_LIS3MDL_I2C_GPIO_SA1_PIN_NUM, res);
+		return -EINVAL;
+	}
+#if CONFIG_LIS3MDL_I2C_ADDR == "0x1E"
+#define LIS3MDL_SA1_VALUE 1
+#else
+#define LIS3MDL_SA1_VALUE 0
+#endif
+	res = gpio_pin_write(gpio_dev, CONFIG_LIS3MDL_GPIO_SA1_PIN_NUM, LIS3MDL_SA1_VALUE);
+	if(res != 0) {
+		SYS_LOG_ERR("Could not write SA1 pin, %d cause res %d", CONFIG_LIS3MDL_GPIO_SA1_PIN_NUM, res);
+		return -EINVAL;
+	}
+#endif
+
+  drv_data->hw_tf = &lis3mdl_i2c_tf;
+
+  return res;
+}

--- a/drivers/sensor/lis3mdl/lis3mdl_spi.c
+++ b/drivers/sensor/lis3mdl/lis3mdl_spi.c
@@ -1,0 +1,148 @@
+
+#include <spi.h>
+#include "lis3mdl.h"
+
+#define LIS3MDL_SPI_READ		(1 << 7)
+#define LIS3MDL_SPI_MS			(1 << 6)
+
+#if defined(CONFIG_LIS3MDL_SPI_GPIO_CS)
+static struct spi_cs_control lis3mdl_cs_ctrl;
+#endif
+
+#define SPI_CS NULL
+
+
+static struct spi_config lis3mdl_spi_conf = {
+	.frequency = CONFIG_LIS3MDL_SPI_BUS_FREQ,
+	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
+		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
+	.slave     = CONFIG_LIS3MDL_SPI_SELECT_SLAVE,
+	.cs        = SPI_CS,
+};
+
+
+static int lis3mdl_raw_read(struct lis3mdl_data *data, u8_t reg_addr,
+			    u8_t *value, u8_t len)
+{
+	struct spi_config *spi_cfg = &lis3mdl_spi_conf;
+	u8_t buffer_tx[2] = { reg_addr | LIS3MDL_SPI_READ | LIS3MDL_SPI_MS, 0 };
+	const struct spi_buf tx_buf = {
+			.buf = buffer_tx,
+			.len = 2,
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+	const struct spi_buf rx_buf[2] = {
+		{
+			.buf = NULL,
+			.len = 1,
+		},
+		{
+			.buf = value,
+			.len = len,
+		}
+	};
+	const struct spi_buf_set rx = {
+		.buffers = rx_buf,
+		.count = 2
+	};
+
+
+	if (len > 64) {
+		return -EIO;
+	}
+
+	if (spi_transceive(data->comm_master, spi_cfg, &tx, &rx)) {
+		return -EIO;
+	}
+	return 0;
+}
+
+static int lis3mdl_raw_write(struct lis3mdl_data *data, u8_t reg_addr,
+			     u8_t *value, u8_t len)
+{
+	struct spi_config *spi_cfg = &lis3mdl_spi_conf;
+	u8_t buffer_tx[1] = { (reg_addr & ~LIS3MDL_SPI_READ) | LIS3MDL_SPI_MS };
+	const struct spi_buf tx_buf[2] = {
+		{
+			.buf = buffer_tx,
+			.len = 1,
+		},
+		{
+			.buf = value,
+			.len = len,
+		}
+	};
+	const struct spi_buf_set tx = {
+		.buffers = tx_buf,
+		.count = 2
+	};
+
+
+	if (len > 64) {
+		return -EIO;
+	}
+
+	if (spi_write(data->comm_master, spi_cfg, &tx)) {
+		return -EIO;
+	}
+	return 0;
+}
+
+static int lis3mdl_spi_read_data(struct lis3mdl_data *data, u8_t reg_addr,
+				 u8_t *value, u8_t len)
+{
+	return lis3mdl_raw_read(data, reg_addr, value, len);
+}
+
+static int lis3mdl_spi_write_data(struct lis3mdl_data *data, u8_t reg_addr,
+				  u8_t *value, u8_t len)
+{
+	return lis3mdl_raw_write(data, reg_addr, value, len);
+}
+
+static int lis3mdl_spi_read_reg(struct lis3mdl_data *data, u8_t reg_addr,
+                                u8_t *value)
+{
+	return lis3mdl_raw_read(data, reg_addr, value, 1);
+}
+
+
+
+static struct lis3mdl_transfer_function lis3mdl_spi_tf = {
+ .read_data = lis3mdl_spi_read_data,
+ .write_data = lis3mdl_spi_write_data,
+ .read_reg = lis3mdl_spi_read_reg,
+};
+
+int lis3mdl_spi_init(struct lis3mdl_data *drv_data) {
+	int res = 0;
+
+#if defined(CONFIG_LIS3MDL_SPI_GPIO_CS)
+	/* handle SPI CS thru GPIO if it is the case */
+	if (IS_ENABLED(CONFIG_LIS3MDL_SPI_GPIO_CS)) {
+		lis3mdl_cs_ctrl.gpio_dev = device_get_binding(
+			CONFIG_LIS3MDL_SPI_GPIO_CS_DRV_NAME);
+		if (!lis3mdl_cs_ctrl.gpio_dev) {
+			SYS_LOG_ERR("Unable to get GPIO SPI CS device");
+			return -ENODEV;
+		}
+
+		lis3mdl_cs_ctrl.gpio_pin = CONFIG_LIS3MDL_SPI_GPIO_CS_PIN;
+		lis3mdl_cs_ctrl.delay = 0;
+
+		lis3mdl_spi_conf.cs = &lis3mdl_cs_ctrl;
+
+		SYS_LOG_DBG("SPI GPIO CS configured on %s:%u",
+			    CONFIG_LIS3MDL_SPI_GPIO_CS_DRV_NAME,
+			    CONFIG_LIS3MDL_SPI_GPIO_CS_PIN);
+	}
+#endif
+
+
+	drv_data->hw_tf = &lis3mdl_spi_tf;
+
+	return res;
+}

--- a/drivers/sensor/lis3mdl/lis3mdl_trigger.c
+++ b/drivers/sensor/lis3mdl/lis3mdl_trigger.c
@@ -5,7 +5,6 @@
  */
 
 #include <device.h>
-#include <i2c.h>
 #include <misc/__assert.h>
 #include <misc/util.h>
 #include <kernel.h>
@@ -21,7 +20,7 @@ int lis3mdl_trigger_set(struct device *dev,
 
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);
 
-	gpio_pin_disable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_INT_PIN_NUM);
+	gpio_pin_disable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM);
 
 	drv_data->data_ready_handler = handler;
 	if (handler == NULL) {
@@ -30,7 +29,16 @@ int lis3mdl_trigger_set(struct device *dev,
 
 	drv_data->data_ready_trigger = *trig;
 
-	gpio_pin_enable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_INT_PIN_NUM);
+	gpio_pin_enable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM);
+
+	/* clear data ready interrupt line by reading sample data, ignore errors */
+	for(int i = 0; i < 2; i++) {
+		if (lis3mdl_sample_fetch(dev, SENSOR_CHAN_MAGN_XYZ) < 0) {
+			SYS_LOG_DBG("Could not clear data ready interrupt line.");
+		}
+	}
+
+	SYS_LOG_DBG("trigger callback set");
 
 	return 0;
 }
@@ -43,15 +51,20 @@ static void lis3mdl_gpio_callback(struct device *dev,
 
 	ARG_UNUSED(pins);
 
-	gpio_pin_disable_callback(dev, CONFIG_LIS3MDL_GPIO_INT_PIN_NUM);
-
-  SYS_LOG_DBG("lis3mdl triggered");
 
 #if defined(CONFIG_LIS3MDL_TRIGGER_OWN_THREAD)
+	gpio_pin_disable_callback(dev, CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM);
 	k_sem_give(&drv_data->gpio_sem);
 #elif defined(CONFIG_LIS3MDL_TRIGGER_GLOBAL_THREAD)
+	gpio_pin_disable_callback(dev, CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM);
 	k_work_submit(&drv_data->work);
+#elif defined(CONFIG_LIS3MDL_TRIGGER_IRQ)
+	if (drv_data->data_ready_handler != NULL) {
+		drv_data->data_ready_handler(dev,
+					     &drv_data->data_ready_trigger);
+	}
 #endif
+
 }
 
 static void lis3mdl_thread_cb(void *arg)
@@ -64,7 +77,7 @@ static void lis3mdl_thread_cb(void *arg)
 					     &drv_data->data_ready_trigger);
 	}
 
-	gpio_pin_enable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_INT_PIN_NUM);
+	gpio_pin_enable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM);
 }
 
 #ifdef CONFIG_LIS3MDL_TRIGGER_OWN_THREAD
@@ -104,13 +117,13 @@ int lis3mdl_init_interrupt(struct device *dev)
 		return -EINVAL;
 	}
 
-	gpio_pin_configure(drv_data->gpio, CONFIG_LIS3MDL_GPIO_INT_PIN_NUM,
+	gpio_pin_configure(drv_data->gpio, CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM,
 			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_INT_ACTIVE_HIGH | GPIO_INT_DEBOUNCE);
+			   GPIO_INT_ACTIVE_HIGH);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   lis3mdl_gpio_callback,
-			   BIT(CONFIG_LIS3MDL_GPIO_INT_PIN_NUM));
+			   BIT(CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM));
 
 	if (gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb) < 0) {
 		SYS_LOG_DBG("Could not set gpio callback.");
@@ -123,12 +136,7 @@ int lis3mdl_init_interrupt(struct device *dev)
 		return -EIO;
 	}
 
-	/* enable interrupt */
-	if (i2c_reg_write_byte(drv_data->i2c, CONFIG_LIS3MDL_I2C_ADDR,
-			       LIS3MDL_REG_INT_CFG, LIS3MDL_INT_XYZ_EN) < 0) {
-		SYS_LOG_DBG("Could not enable interrupt.");
-		return -EIO;
-	}
+  //TODO allow for using DRDY or INT to trigger on
 
   SYS_LOG_DBG("lis3mdl trigger setup complete");
 
@@ -145,7 +153,7 @@ int lis3mdl_init_interrupt(struct device *dev)
 	drv_data->dev = dev;
 #endif
 
-	gpio_pin_enable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_INT_PIN_NUM);
+	gpio_pin_enable_callback(drv_data->gpio, CONFIG_LIS3MDL_GPIO_DRDY_PIN_NUM);
 
 	return 0;
 }


### PR DESCRIPTION
Adds support for SPI and direct IRQ trigger callbacks from the dataready line from a LIS3MDL sensor